### PR TITLE
Bit of everything

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ app-example
 # generated native folders
 /ios
 /android
+
+# ip-address constant
+constants/computer-ip.ts

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,3 @@ app-example
 # generated native folders
 /ios
 /android
-
-# ip-address constant
-constants/computer-ip.ts

--- a/app.json
+++ b/app.json
@@ -47,7 +47,8 @@
           "barcodeScannerEnabled": true,
           "recordAudioAndroid": false
         }
-      ]
+      ],
+      "expo-secure-store"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -16,12 +16,13 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { NoticeBar } from "@/components/home/notice-bar";
 import { NoticeDetailComponent } from "@/components/home/notice-detail-component";
 import { ProfileComponent } from "@/components/home/profile-component";
+import { computer_ip_address } from "@/constants/computer-ip";
 import { TEST_NOTICES } from "@/constants/test-notices";
 import { getEmail, getJwt, saveRole } from "@/utils/auth-token";
+import { saveInfo } from "@/utils/user-info";
 
 const FEATURED_NOTICE = TEST_NOTICES[0];
 const FOLLOWING_NOTICES = TEST_NOTICES.slice(1);
-const computer_ip_address = "";
 
 export default function HomePage() {
   const insets = useSafeAreaInsets();
@@ -33,6 +34,8 @@ export default function HomePage() {
     AlanSans_700Bold,
     Grandstander_900Black,
   });
+  const [name, setName] = useState("");
+  const [teamName, setTeamName] = useState("");
 
   useFocusEffect(
     //this will mount every time the tab is focused on. change back to useEffect
@@ -69,7 +72,9 @@ export default function HomePage() {
         if (!active) return;
 
         await saveRole(userData.role);
-        console.log(userData);
+        await saveInfo("name", userData.name);
+        setName(userData.name);
+        setTeamName(userData.teamName);
       })();
 
       return () => {
@@ -86,9 +91,9 @@ export default function HomePage() {
     <View style={styles.screen}>
       <View style={{ paddingTop: insets.top }}>
         <ProfileComponent
-          name="Taeeun K."
+          name={name}
           onSettingsPress={() => router.push("/settings")}
-          teamName="Team Name"
+          teamName={teamName}
         />
       </View>
 

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -72,7 +72,11 @@ export default function HomePage() {
         if (!active) return;
 
         await saveRole(userData.role);
-        await saveInfo("name", userData.name);
+        await saveInfo("name", userData.name ?? "");
+        await saveInfo("id", String(userData.id ?? ""));
+        await saveInfo("teamName", userData.teamName ?? "");
+        await saveInfo("checkedIn", String(!!userData.checkedIn));
+        console.log(String(!!userData.checkedIn));
         setName(userData.name);
         setTeamName(userData.teamName);
       })();

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -1,13 +1,13 @@
 import {
-    AlanSans_400Regular,
-    AlanSans_500Medium,
-    AlanSans_700Bold,
+  AlanSans_400Regular,
+  AlanSans_500Medium,
+  AlanSans_700Bold,
 } from "@expo-google-fonts/alan-sans"; // fonts
 import { Grandstander_900Black } from "@expo-google-fonts/grandstander";
 import { useFonts } from "expo-font";
 import { LinearGradient } from "expo-linear-gradient";
 import { useRouter } from "expo-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -15,9 +15,11 @@ import { NoticeBar } from "@/components/home/notice-bar";
 import { NoticeDetailComponent } from "@/components/home/notice-detail-component";
 import { ProfileComponent } from "@/components/home/profile-component";
 import { TEST_NOTICES } from "@/constants/test-notices";
+import { getEmail, getJwt } from "@/utils/auth-token";
 
 const FEATURED_NOTICE = TEST_NOTICES[0];
 const FOLLOWING_NOTICES = TEST_NOTICES.slice(1);
+const computer_ip_address = "192.168.1.126";
 
 export default function HomePage() {
   const insets = useSafeAreaInsets();
@@ -29,6 +31,29 @@ export default function HomePage() {
     AlanSans_700Bold,
     Grandstander_900Black,
   });
+
+  useEffect(() => {
+    (async () => {
+      const jwt = await getJwt();
+      const email = await getEmail();
+      if (!jwt || !email) return;
+
+      const response = await fetch(
+        `http://${computer_ip_address}:8080/api/users/${email}`,
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${jwt}`,
+          },
+        },
+      );
+      if (!response.ok) return;
+
+      const userData = await response.json();
+      console.log("role:", userData.role);
+    })();
+  }, []);
 
   if (!fontsLoaded) {
     return <View style={styles.screen} />;

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -4,10 +4,12 @@ import {
   AlanSans_700Bold,
 } from "@expo-google-fonts/alan-sans"; // fonts
 import { Grandstander_900Black } from "@expo-google-fonts/grandstander";
+import { useFocusEffect } from "@react-navigation/native";
 import { useFonts } from "expo-font";
 import { LinearGradient } from "expo-linear-gradient";
 import { useRouter } from "expo-router";
-import { useEffect, useState } from "react";
+import { fetch } from "expo/fetch";
+import { useCallback, useState } from "react";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -19,7 +21,7 @@ import { getEmail, getJwt, saveRole } from "@/utils/auth-token";
 
 const FEATURED_NOTICE = TEST_NOTICES[0];
 const FOLLOWING_NOTICES = TEST_NOTICES.slice(1);
-const computer_ip_address = "192.168.1.126";
+const computer_ip_address = "";
 
 export default function HomePage() {
   const insets = useSafeAreaInsets();
@@ -32,30 +34,49 @@ export default function HomePage() {
     Grandstander_900Black,
   });
 
-  useEffect(() => {
-    (async () => {
-      const jwt = await getJwt();
-      const email = await getEmail();
+  useFocusEffect(
+    //this will mount every time the tab is focused on. change back to useEffect
+    //for production and make it remount after ever log in! Maybe when jwt changes?
+    useCallback(() => {
+      let active = true;
 
-      if (!jwt || !email) return;
+      (async () => {
+        const jwt = await getJwt();
+        const email = await getEmail();
 
-      const response = await fetch(
-        `http://${computer_ip_address}:8080/api/users/${email}`,
-        {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${jwt}`,
+        if (!jwt || !email || !active) return;
+
+        // Use expo/fetch + credentials: "omit" so a manual Cookie header is sent.
+        // RN's built-in fetch treats Cookie as managed and often strips it (403).
+        const response = await fetch(
+          `http://${computer_ip_address}:8080/api/users/${email}`,
+          {
+            method: "GET",
+            credentials: "omit",
+            headers: {
+              "Content-Type": "application/json",
+              Cookie: `token=${jwt}`,
+            },
           },
-        },
-      );
-      if (!response.ok) return;
+        );
 
-      const userData = await response.json();
-      await saveRole(String(userData.role ?? ""));
-      console.log("role:", userData.role);
-    })();
-  }, []);
+        if (!response.ok) {
+          console.log(response.status, await response.text());
+          return;
+        }
+
+        const userData = await response.json();
+        if (!active) return;
+
+        await saveRole(userData.role);
+        console.log(userData);
+      })();
+
+      return () => {
+        active = false;
+      };
+    }, []),
+  );
 
   if (!fontsLoaded) {
     return <View style={styles.screen} />;

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -16,7 +16,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { NoticeBar } from "@/components/home/notice-bar";
 import { NoticeDetailComponent } from "@/components/home/notice-detail-component";
 import { ProfileComponent } from "@/components/home/profile-component";
-import { computer_ip_address } from "@/constants/computer-ip";
+import { API_BASE_URL } from "@/constants/computer-ip";
 import { TEST_NOTICES } from "@/constants/test-notices";
 import { getEmail, getJwt, saveRole } from "@/utils/auth-token";
 import { saveInfo } from "@/utils/user-info";
@@ -52,7 +52,7 @@ export default function HomePage() {
         // Use expo/fetch + credentials: "omit" so a manual Cookie header is sent.
         // RN's built-in fetch treats Cookie as managed and often strips it (403).
         const response = await fetch(
-          `http://${computer_ip_address}:8080/api/users/${email}`,
+          `${API_BASE_URL}/api/users/${email}`,
           {
             method: "GET",
             credentials: "omit",

--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -15,7 +15,7 @@ import { NoticeBar } from "@/components/home/notice-bar";
 import { NoticeDetailComponent } from "@/components/home/notice-detail-component";
 import { ProfileComponent } from "@/components/home/profile-component";
 import { TEST_NOTICES } from "@/constants/test-notices";
-import { getEmail, getJwt } from "@/utils/auth-token";
+import { getEmail, getJwt, saveRole } from "@/utils/auth-token";
 
 const FEATURED_NOTICE = TEST_NOTICES[0];
 const FOLLOWING_NOTICES = TEST_NOTICES.slice(1);
@@ -36,6 +36,7 @@ export default function HomePage() {
     (async () => {
       const jwt = await getJwt();
       const email = await getEmail();
+
       if (!jwt || !email) return;
 
       const response = await fetch(
@@ -51,6 +52,7 @@ export default function HomePage() {
       if (!response.ok) return;
 
       const userData = await response.json();
+      await saveRole(String(userData.role ?? ""));
       console.log("role:", userData.role);
     })();
   }, []);

--- a/app/(tabs)/(home)/settings.tsx
+++ b/app/(tabs)/(home)/settings.tsx
@@ -9,7 +9,7 @@ import { useFonts } from "expo-font";
 import { useRouter } from "expo-router";
 import { Alert, Pressable, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { clearEmail, clearJwt } from "../../../utils/auth-token";
+import { clearEmail, clearJwt, clearRole } from "../../../utils/auth-token";
 
 export default function SettingsScreen() {
   const router = useRouter();
@@ -29,6 +29,7 @@ export default function SettingsScreen() {
         onPress: async () => {
           await clearJwt();
           await clearEmail();
+          await clearRole();
           router.replace("/login");
         },
       },

--- a/app/(tabs)/(home)/settings.tsx
+++ b/app/(tabs)/(home)/settings.tsx
@@ -9,7 +9,7 @@ import { useFonts } from "expo-font";
 import { useRouter } from "expo-router";
 import { Alert, Pressable, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { clearJwt } from "../../../utils/auth-token";
+import { clearEmail, clearJwt } from "../../../utils/auth-token";
 
 export default function SettingsScreen() {
   const router = useRouter();
@@ -28,6 +28,7 @@ export default function SettingsScreen() {
         style: "destructive",
         onPress: async () => {
           await clearJwt();
+          await clearEmail();
           router.replace("/login");
         },
       },

--- a/app/(tabs)/(home)/settings.tsx
+++ b/app/(tabs)/(home)/settings.tsx
@@ -9,6 +9,7 @@ import { useFonts } from "expo-font";
 import { useRouter } from "expo-router";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { clearJwt } from "../../../utils/auth-token";
 
 export default function SettingsScreen() {
   const router = useRouter();
@@ -37,7 +38,10 @@ export default function SettingsScreen() {
               accessibilityLabel="Log out"
               accessibilityRole="button"
               hitSlop={8}
-              onPress={() => {}}
+              onPress={async () => {
+                await clearJwt();
+                router.replace("/login");
+              }}
               style={({ pressed }) => [
                 styles.logoutButton,
                 pressed && styles.pressed,

--- a/app/(tabs)/(home)/settings.tsx
+++ b/app/(tabs)/(home)/settings.tsx
@@ -7,9 +7,11 @@ import { Grandstander_900Black } from "@expo-google-fonts/grandstander";
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { useFonts } from "expo-font";
 import { useRouter } from "expo-router";
+import { useEffect, useState } from "react";
 import { Alert, Pressable, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { clearEmail, clearJwt, clearRole } from "../../../utils/auth-token";
+import { clearEmail, clearJwt, clearRole, getEmail } from "../../../utils/auth-token";
+import { getInfo } from "../../../utils/user-info";
 
 export default function SettingsScreen() {
   const router = useRouter();
@@ -19,6 +21,21 @@ export default function SettingsScreen() {
     AlanSans_700Bold,
     Grandstander_900Black,
   });
+  const [name, setName] = useState("");
+  const [id, setId] = useState("");
+  const [email, setEmail] = useState("");
+  const [teamName, setTeamName] = useState("");
+  const [checkedIn, setCheckedIn] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      setName((await getInfo("name")) ?? "");
+      setId((await getInfo("id")) ?? "");
+      setEmail((await getEmail()) ?? "");
+      setTeamName((await getInfo("teamName")) ?? "");
+      setCheckedIn((await getInfo("checkedIn")) === "true");
+    })();
+  }, []);
 
   const handleLogout = () => {
     Alert.alert("Log out", "Are you sure you want to log out?", [
@@ -45,7 +62,7 @@ export default function SettingsScreen() {
       <View style={styles.content}>
         <View style={styles.profileHeader}>
           <View style={styles.identity}>
-            <Text style={styles.name}>Taeeun K.</Text>
+            <Text style={styles.name}>{name}</Text>
             <Text style={styles.profileLabel}>Profile</Text>
           </View>
 
@@ -85,14 +102,19 @@ export default function SettingsScreen() {
 
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Information</Text>
-          <InfoRow label="ID" value="@Name" />
-          <InfoRow label="Email" value="jyweva@ewha.ac.kr" />
+          <InfoRow label="ID" value={id} />
+          <InfoRow label="Email" value={email} />
         </View>
 
         <View style={[styles.section, styles.activitySection]}>
           <Text style={styles.sectionTitle}>Activity</Text>
-          <InfoRow label="Team" pill value="Team Name" />
-          <InfoRow label="Check in" pill value="Valid" />
+          <InfoRow label="Team" pill value={teamName} />
+          <InfoRow
+            label="Check in"
+            pill
+            pillColor={checkedIn ? undefined : "#E53935"}
+            value={checkedIn ? "Valid" : "Invalid"}
+          />
         </View>
       </View>
     </SafeAreaView>
@@ -102,15 +124,16 @@ export default function SettingsScreen() {
 type InfoRowProps = {
   label: string;
   pill?: boolean;
+  pillColor?: string;
   value: string;
 };
 
-function InfoRow({ label, pill = false, value }: InfoRowProps) {
+function InfoRow({ label, pill = false, pillColor, value }: InfoRowProps) {
   return (
     <View style={styles.infoRow}>
       <Text style={styles.infoLabel}>{label}</Text>
       {pill ? (
-        <View style={styles.pill}>
+        <View style={[styles.pill, pillColor ? { backgroundColor: pillColor } : null]}>
           <Text style={styles.pillText}>{value}</Text>
         </View>
       ) : (

--- a/app/(tabs)/(home)/settings.tsx
+++ b/app/(tabs)/(home)/settings.tsx
@@ -7,7 +7,7 @@ import { Grandstander_900Black } from "@expo-google-fonts/grandstander";
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { useFonts } from "expo-font";
 import { useRouter } from "expo-router";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Alert, Pressable, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { clearJwt } from "../../../utils/auth-token";
 
@@ -19,6 +19,20 @@ export default function SettingsScreen() {
     AlanSans_700Bold,
     Grandstander_900Black,
   });
+
+  const handleLogout = () => {
+    Alert.alert("Log out", "Are you sure you want to log out?", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Log out",
+        style: "destructive",
+        onPress: async () => {
+          await clearJwt();
+          router.replace("/login");
+        },
+      },
+    ]);
+  };
 
   if (!fontsLoaded) {
     return <View style={styles.screen} />;
@@ -38,10 +52,7 @@ export default function SettingsScreen() {
               accessibilityLabel="Log out"
               accessibilityRole="button"
               hitSlop={8}
-              onPress={async () => {
-                await clearJwt();
-                router.replace("/login");
-              }}
+              onPress={handleLogout}
               style={({ pressed }) => [
                 styles.logoutButton,
                 pressed && styles.pressed,

--- a/app/(tabs)/qrcode.tsx
+++ b/app/(tabs)/qrcode.tsx
@@ -1,3 +1,4 @@
+import { getRole } from "@/utils/auth-token";
 import { Fredoka_700Bold, useFonts } from "@expo-google-fonts/fredoka";
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { useFocusEffect, useIsFocused } from "@react-navigation/native";
@@ -17,11 +18,10 @@ import {
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { getRole } from "@/utils/auth-token";
 
 export default function QRCodeScreen() {
   const originalBrightness = useRef<number | null>(null);
-  const computer_ip_address = "192.168.1.126";
+  const computer_ip_address = "";
   const insets = useSafeAreaInsets();
   const isFocused = useIsFocused();
   const [searchQuery, setSearchQuery] = useState("");
@@ -32,14 +32,16 @@ export default function QRCodeScreen() {
     Fredoka_700Bold,
   });
   const [qrCode, setQrCode] = useState("");
-  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(false);
 
   useEffect(() => {
     (async () => {
       const role = await getRole();
-      setIsAdmin(!!role && role.toUpperCase().includes("ADMIN"));
+      setIsAdmin(!!role && role.includes("admin"));
     })();
   }, []);
+
+  console.log(`is admin: ${isAdmin}`);
 
   useFocusEffect(
     useCallback(() => {

--- a/app/(tabs)/qrcode.tsx
+++ b/app/(tabs)/qrcode.tsx
@@ -7,7 +7,7 @@ import {
   useCameraPermissions,
   type BarcodeScanningResult,
 } from "expo-camera";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Image,
   Pressable,
@@ -17,10 +17,10 @@ import {
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { getRole } from "@/utils/auth-token";
 
 export default function QRCodeScreen() {
   const originalBrightness = useRef<number | null>(null);
-  const isAdmin = true;
   const computer_ip_address = "192.168.1.126";
   const insets = useSafeAreaInsets();
   const isFocused = useIsFocused();
@@ -32,11 +32,19 @@ export default function QRCodeScreen() {
     Fredoka_700Bold,
   });
   const [qrCode, setQrCode] = useState("");
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const role = await getRole();
+      setIsAdmin(!!role && role.toUpperCase().includes("ADMIN"));
+    })();
+  }, []);
 
   useFocusEffect(
     useCallback(() => {
-      if (isAdmin) {
-        setScanned(false);
+      if (isAdmin !== false) {
+        if (isAdmin) setScanned(false);
         return;
       }
 
@@ -134,6 +142,10 @@ export default function QRCodeScreen() {
   const handleDismissScanResult = useCallback(() => {
     setScanned(false);
   }, []);
+
+  if (isAdmin === null) {
+    return <View style={styles.pageContainer} />;
+  }
 
   if (isAdmin) {
     const cameraReady = cameraActive && permission?.granted && isFocused;

--- a/app/(tabs)/qrcode.tsx
+++ b/app/(tabs)/qrcode.tsx
@@ -65,17 +65,15 @@ export default function QRCodeScreen() {
 
       (async () => {
         const jwt = await getJwt();
-        const response = await fetch(
-          `${API_BASE_URL}/api/users/me/qr`,
-          {
-            method: "GET",
-            headers: {
-              "Content-Type": "application/json",
-              Cookie: `token=${jwt}`,
-            },
+        const response = await fetch(`${API_BASE_URL}/api/users/me/qr`, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `token=${jwt}`,
           },
-        );
+        });
         if (!response.ok) {
+          console.log(response);
           return;
         }
 
@@ -108,20 +106,17 @@ export default function QRCodeScreen() {
 
       (async () => {
         try {
-          await fetch(
-            `${API_BASE_URL}/api/admin/award-points-fast`,
-            {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({
-                token: result.data,
-                amount: 1,
-                eventId: "temp",
-              }),
+          await fetch(`${API_BASE_URL}/api/admin/award-points-fast`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
             },
-          );
+            body: JSON.stringify({
+              token: result.data,
+              amount: 1,
+              eventId: "temp",
+            }),
+          });
           await console.log(result.data);
         } catch {
           // request failed

--- a/app/(tabs)/qrcode.tsx
+++ b/app/(tabs)/qrcode.tsx
@@ -1,3 +1,4 @@
+import { computer_ip_address } from "@/constants/computer-ip";
 import { getRole } from "@/utils/auth-token";
 import { Fredoka_700Bold, useFonts } from "@expo-google-fonts/fredoka";
 import Ionicons from "@expo/vector-icons/Ionicons";
@@ -21,7 +22,6 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 export default function QRCodeScreen() {
   const originalBrightness = useRef<number | null>(null);
-  const computer_ip_address = "";
   const insets = useSafeAreaInsets();
   const isFocused = useIsFocused();
   const [searchQuery, setSearchQuery] = useState("");

--- a/app/(tabs)/qrcode.tsx
+++ b/app/(tabs)/qrcode.tsx
@@ -1,5 +1,5 @@
 import { computer_ip_address } from "@/constants/computer-ip";
-import { getRole } from "@/utils/auth-token";
+import { getJwt, getRole } from "@/utils/auth-token";
 import { Fredoka_700Bold, useFonts } from "@expo-google-fonts/fredoka";
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { useFocusEffect, useIsFocused } from "@react-navigation/native";
@@ -64,12 +64,14 @@ export default function QRCodeScreen() {
       })();
 
       (async () => {
+        const jwt = await getJwt();
         const response = await fetch(
           `http://${computer_ip_address}:8080/api/users/me/qr`,
           {
             method: "GET",
             headers: {
               "Content-Type": "application/json",
+              Cookie: `token=${jwt}`,
             },
           },
         );

--- a/app/(tabs)/qrcode.tsx
+++ b/app/(tabs)/qrcode.tsx
@@ -1,4 +1,4 @@
-import { computer_ip_address } from "@/constants/computer-ip";
+import { API_BASE_URL } from "@/constants/computer-ip";
 import { getJwt, getRole } from "@/utils/auth-token";
 import { Fredoka_700Bold, useFonts } from "@expo-google-fonts/fredoka";
 import Ionicons from "@expo/vector-icons/Ionicons";
@@ -66,7 +66,7 @@ export default function QRCodeScreen() {
       (async () => {
         const jwt = await getJwt();
         const response = await fetch(
-          `http://${computer_ip_address}:8080/api/users/me/qr`,
+          `${API_BASE_URL}/api/users/me/qr`,
           {
             method: "GET",
             headers: {
@@ -109,7 +109,7 @@ export default function QRCodeScreen() {
       (async () => {
         try {
           await fetch(
-            `http://${computer_ip_address}:8080/api/admin/award-points-fast`,
+            `${API_BASE_URL}/api/admin/award-points-fast`,
             {
               method: "POST",
               headers: {

--- a/app/(tabs)/qrcode.tsx
+++ b/app/(tabs)/qrcode.tsx
@@ -20,8 +20,8 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 export default function QRCodeScreen() {
   const originalBrightness = useRef<number | null>(null);
-  const isAdmin = false;
-  const computer_ip_address = "";
+  const isAdmin = true;
+  const computer_ip_address = "192.168.1.126";
   const insets = useSafeAreaInsets();
   const isFocused = useIsFocused();
   const [searchQuery, setSearchQuery] = useState("");
@@ -93,8 +93,29 @@ export default function QRCodeScreen() {
     (result: BarcodeScanningResult) => {
       if (scanned) return;
       setScanned(true);
-      // TODO: handle scanned QR data (e.g. look up attendee)
-      console.log("Scanned QR:", result.data);
+
+      (async () => {
+        try {
+          await fetch(
+            `http://${computer_ip_address}:8080/api/admin/award-points-fast`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                token: result.data,
+                amount: 1,
+                eventId: "temp",
+              }),
+            },
+          );
+          await console.log(result.data);
+        } catch {
+          // request failed
+          console.log("Scanning failed");
+        }
+      })();
     },
     [scanned],
   );

--- a/app/(tabs)/qrcode.tsx
+++ b/app/(tabs)/qrcode.tsx
@@ -8,13 +8,20 @@ import {
   type BarcodeScanningResult,
 } from "expo-camera";
 import { useCallback, useRef, useState } from "react";
-import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
-import QRCode from "react-native-qrcode-svg";
+import {
+  Image,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 export default function QRCodeScreen() {
   const originalBrightness = useRef<number | null>(null);
   const isAdmin = false;
+  const computer_ip_address = "";
   const insets = useSafeAreaInsets();
   const isFocused = useIsFocused();
   const [searchQuery, setSearchQuery] = useState("");
@@ -24,6 +31,7 @@ export default function QRCodeScreen() {
   const [fontsLoaded] = useFonts({
     Fredoka_700Bold,
   });
+  const [qrCode, setQrCode] = useState("");
 
   useFocusEffect(
     useCallback(() => {
@@ -43,6 +51,29 @@ export default function QRCodeScreen() {
             // brightness control not available
           }
         }
+      })();
+
+      (async () => {
+        const response = await fetch(
+          `http://${computer_ip_address}:8080/api/users/me/qr`,
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          },
+        );
+        if (!response.ok) {
+          return;
+        }
+
+        const blob = await response.blob();
+        const reader = new FileReader();
+        reader.onloadend = () => {
+          const dataUri = reader.result as string;
+          setQrCode(dataUri);
+        };
+        reader.readAsDataURL(blob);
       })();
 
       return () => {
@@ -308,19 +339,13 @@ export default function QRCodeScreen() {
       <View
         style={{ flex: 0.9, alignItems: "center", justifyContent: "center" }}
       >
-        <View
-          style={{
-            backgroundColor: "#f7f7f7",
-            padding: 20,
-            borderRadius: 10,
-          }}
-        >
-          <QRCode
-            value="https://expo.dev"
-            size={250}
-            color="#A3CE26"
-            backgroundColor="white"
-          />
+        <View>
+          {qrCode ? (
+            <Image
+              source={{ uri: qrCode }}
+              style={{ width: 300, height: 300, borderRadius: 10 }}
+            />
+          ) : null}
         </View>
         <Text style={styles.instructionText}>
           Please show your{" "}

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -15,7 +15,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import { saveJwt } from "../utils/auth-token";
+import { saveEmail, saveJwt } from "../utils/auth-token";
 
 export default function Login() {
   const [email, setEmail] = useState<string>("");
@@ -128,7 +128,7 @@ export default function Login() {
     },
   });
 
-  const computer_ip_address = ""; //for development, DON'T PUSH YOUR IP ADDRESS TO GITHUB!
+  const computer_ip_address = "192.168.1.126"; //for development, DON'T PUSH YOUR IP ADDRESS TO GITHUB!
 
   const handleLogin = async () => {
     setErrorMessage(null);
@@ -163,10 +163,8 @@ export default function Login() {
         return;
       }
 
-      console.log(jwt);
-      console.log("\n");
-
       await saveJwt(jwt);
+      await saveEmail(email);
       router.replace("/(tabs)/(home)");
     } catch {
       setErrorMessage("Unable to connect to server");

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -15,7 +15,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import { computer_ip_address } from "@/constants/computer-ip";
+import { API_BASE_URL } from "@/constants/computer-ip";
 import { saveEmail, saveJwt } from "../utils/auth-token";
 
 export default function Login() {
@@ -139,7 +139,7 @@ export default function Login() {
 
     try {
       const response = await fetch(
-        `http://${computer_ip_address}:8080/auth/login`,
+        `${API_BASE_URL}/auth/login`,
         {
           method: "POST",
           headers: {

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -15,6 +15,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { computer_ip_address } from "@/constants/computer-ip";
 import { saveEmail, saveJwt } from "../utils/auth-token";
 
 export default function Login() {
@@ -127,8 +128,6 @@ export default function Login() {
       height: 28,
     },
   });
-
-  const computer_ip_address = ""; //for development, DON'T PUSH YOUR IP ADDRESS TO GITHUB!
 
   const handleLogin = async () => {
     setErrorMessage(null);

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -128,7 +128,7 @@ export default function Login() {
     },
   });
 
-  const computer_ip_address = "192.168.1.126"; //for development, DON'T PUSH YOUR IP ADDRESS TO GITHUB!
+  const computer_ip_address = ""; //for development, DON'T PUSH YOUR IP ADDRESS TO GITHUB!
 
   const handleLogin = async () => {
     setErrorMessage(null);
@@ -165,6 +165,7 @@ export default function Login() {
 
       await saveJwt(jwt);
       await saveEmail(email);
+      console.log(jwt);
       router.replace("/(tabs)/(home)");
     } catch {
       setErrorMessage("Unable to connect to server");

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -15,6 +15,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { saveJwt } from "../utils/auth-token";
 
 export default function Login() {
   const [email, setEmail] = useState<string>("");
@@ -155,9 +156,17 @@ export default function Login() {
       }
 
       const data = await response.json();
-      const jwt = data.jwt;
-      console.log(jwt);
+      const jwt = data.token;
 
+      if (!jwt) {
+        setErrorMessage("Login failed");
+        return;
+      }
+
+      console.log(jwt);
+      console.log("\n");
+
+      await saveJwt(jwt);
       router.replace("/(tabs)/(home)");
     } catch {
       setErrorMessage("Unable to connect to server");

--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -186,16 +186,13 @@ export default function Signup() {
     }
 
     try {
-      const response = await fetch(
-        `${API_BASE_URL}/api/users/register`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ name, email, password }),
+      const response = await fetch(`${API_BASE_URL}/api/users/register`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
         },
-      );
+        body: JSON.stringify({ name, email, password }),
+      });
 
       if (!response.ok) {
         setErrorMessage("Signup failed");

--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -141,7 +141,7 @@ export default function Signup() {
     },
   });
 
-  const computer_ip_address = "192.168.1.126"; //for development, DON'T PUSH YOUR IP ADDRESS TO GITHUB!
+  const computer_ip_address = ""; //for development, DON'T PUSH YOUR IP ADDRESS TO GITHUB!
 
   const invalidPassword = (password: string) => {
     let hasAlpha = false; // anything that's alphabetic

--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -141,7 +141,7 @@ export default function Signup() {
     },
   });
 
-  const computer_ip_address = ""; //for development, DON'T PUSH YOUR IP ADDRESS TO GITHUB!
+  const computer_ip_address = "192.168.1.126"; //for development, DON'T PUSH YOUR IP ADDRESS TO GITHUB!
 
   const invalidPassword = (password: string) => {
     let hasAlpha = false; // anything that's alphabetic

--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -17,6 +17,7 @@ import {
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { computer_ip_address } from "@/constants/computer-ip";
 
 export default function Signup() {
   const insets = useSafeAreaInsets();
@@ -140,8 +141,6 @@ export default function Signup() {
       height: 28,
     },
   });
-
-  const computer_ip_address = ""; //for development, DON'T PUSH YOUR IP ADDRESS TO GITHUB!
 
   const invalidPassword = (password: string) => {
     let hasAlpha = false; // anything that's alphabetic

--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -1,3 +1,4 @@
+import { computer_ip_address } from "@/constants/computer-ip";
 import {
   Fredoka_600SemiBold,
   Fredoka_700Bold,
@@ -17,11 +18,10 @@ import {
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { computer_ip_address } from "@/constants/computer-ip";
 
 export default function Signup() {
   const insets = useSafeAreaInsets();
-  const [username, setUsername] = useState<string>("");
+  const [name, setName] = useState<string>("");
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [confirmPassword, setConfirmPassword] = useState<string>("");
@@ -163,7 +163,7 @@ export default function Signup() {
   const handleSignup = async () => {
     setErrorMessage(null);
 
-    if (!username || !email || !password || !confirmPassword) {
+    if (!name || !email || !password || !confirmPassword) {
       setErrorMessage("Please fill in all fields");
       return;
     }
@@ -193,7 +193,7 @@ export default function Signup() {
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ username, email, password }),
+          body: JSON.stringify({ name, email, password }),
         },
       );
 
@@ -234,8 +234,8 @@ export default function Signup() {
         <TextInput
           placeholder="@Name"
           style={styles.input}
-          value={username}
-          onChangeText={setUsername}
+          value={name}
+          onChangeText={setName}
           autoCapitalize="none"
         />
         <TextInput

--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -1,4 +1,4 @@
-import { computer_ip_address } from "@/constants/computer-ip";
+import { API_BASE_URL } from "@/constants/computer-ip";
 import {
   Fredoka_600SemiBold,
   Fredoka_700Bold,
@@ -187,7 +187,7 @@ export default function Signup() {
 
     try {
       const response = await fetch(
-        `http://${computer_ip_address}:8080/api/users/register`,
+        `${API_BASE_URL}/api/users/register`,
         {
           method: "POST",
           headers: {

--- a/constants/computer-ip.ts
+++ b/constants/computer-ip.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = "https://api-gdff.onrender.com";

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",
+        "expo-secure-store": "~15.0.8",
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
         "expo-symbols": "~1.0.8",
@@ -70,7 +71,8 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -100,7 +102,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1763,7 +1764,8 @@
       "resolved": "https://registry.npmjs.org/@expo-google-fonts/material-symbols/-/material-symbols-0.4.38.tgz",
       "integrity": "sha512-IJkBtN1o8u9BW5fvSii1MyHPQ7Q0HxbWcVBvOrOzgMLpVtZw7R2w94wBTVR7kZwv3w1JNTESMmLA5Sqn1+Z36A==",
       "license": "MIT AND Apache-2.0",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",
@@ -1902,6 +1904,7 @@
       "integrity": "sha512-zBZw52KnaHf9zGVp1eJk8kNfc+5ArGf+KvTL3SeMsr03K6tPJtLbgycVLjrAiLMfhzqGVjPD2G+rbNwpbLUxcg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "peerDependencies": {
         "expo": "*",
         "react": "*",
@@ -2043,6 +2046,7 @@
       "integrity": "sha512-tt9x76IEE8hp2FWTLPfEArrTyD7GCoUe3TpohESy+SPZ/OqkUnSXz40xnUuE0XbE132z8c5CRCfXQLM9DTEknQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@expo/dom-webview": "^57.0.0",
         "anser": "^1.4.9",
@@ -2840,7 +2844,6 @@
       "resolved": "https://registry.npmjs.org/@react-native-masked-view/masked-view/-/masked-view-0.3.2.tgz",
       "integrity": "sha512-XwuQoW7/GEgWRMovOQtX3A4PrXhyaZm0lVUiY8qJDvdngjLms9Cpdck6SmGAUNqQwcj2EadHC1HwL0bEyoa/SQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": ">=16",
         "react-native": ">=0.57"
@@ -3140,7 +3143,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.1.tgz",
       "integrity": "sha512-ohiGfR5kX585aADiYt+nfwdqmJjj5W/1eXN9CQ/njhQNi/sMmjaxYppS+e0E0zW+z5b4gaLFBvqLrJcvOdtLUA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.17.1",
         "escape-string-regexp": "^4.0.0",
@@ -3218,6 +3220,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3238,6 +3241,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3251,6 +3255,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3265,7 +3270,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -3273,6 +3279,7 @@
       "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
@@ -3292,7 +3299,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@testing-library/user-event": {
       "version": "14.6.1",
@@ -3300,6 +3308,7 @@
       "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12",
         "npm": ">=6"
@@ -3324,7 +3333,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3442,7 +3452,6 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3513,7 +3522,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -4101,7 +4109,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4251,6 +4258,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4806,7 +4814,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5323,7 +5330,8 @@
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -5518,6 +5526,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5571,7 +5580,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -5938,7 +5948,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6135,7 +6144,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6374,7 +6382,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.35.tgz",
       "integrity": "sha512-E+tXpQwjGm5fK/uwa55p0Xx/kuo5dXDKfVJ95IargTNa5KiFt26lSTXXa9KnHbI4EDLwFD38/xTKZvzPTlGTdg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.25",
@@ -6472,7 +6479,6 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
       "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8"
@@ -6497,7 +6503,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.12.tgz",
       "integrity": "sha512-QQzunE2Mxk45AsCWm3tK7OpVljbtVnKD58q4/qliev+cbye1IOduUnRIdD+P7DyButw17G9MTX795kgaQiz5hQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -6513,6 +6518,7 @@
       "integrity": "sha512-QadzKSKpjXOlkIEnkX7SqHwCgUJZLjhWUvg1AauaUgKVnz35Ror41juM4y+KNr9pFxnukSDUz8L+UvdZVCNu6Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "peerDependencies": {
         "expo": "*",
         "react": "*",
@@ -6571,7 +6577,6 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.12.tgz",
       "integrity": "sha512-FpXeIpFgZuxihwT9lBo86YD3y6LphBuAhN680MMxm/Y7fmsc57vimn2d3vFu68VI0+Z9w457t494mu2wvlgWTQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.13",
         "invariant": "^2.2.4"
@@ -6863,6 +6868,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/expo-secure-store": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-15.0.8.tgz",
+      "integrity": "sha512-lHnzvRajBu4u+P99+0GEMijQMFCOYpWRO4dWsXSuMt77+THPIGjzNvVKrGSl6mMrLsfVaKL8BpwYZLGlgA+zAw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-server": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.7.tgz",
@@ -7032,7 +7046,8 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
       "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/expo/node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.3",
@@ -7040,6 +7055,7 @@
       "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -7056,6 +7072,7 @@
       "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -7072,6 +7089,7 @@
       "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -7088,6 +7106,7 @@
       "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.2"
       },
@@ -7107,6 +7126,7 @@
       "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.3"
       },
@@ -7126,6 +7146,7 @@
       "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -7142,6 +7163,7 @@
       "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@radix-ui/react-use-effect-event": "0.0.3",
         "@radix-ui/react-use-layout-effect": "1.1.2"
@@ -7162,6 +7184,7 @@
       "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.2"
       },
@@ -7181,6 +7204,7 @@
       "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -7221,6 +7245,7 @@
       "integrity": "sha512-3Zr+UsTXPiUyGktGqqP0byXH02Yp7lsdmasenuZAMEn89cjD8Rs9j8o7kikjOzb+QnTR1lofgYu21QhpvCf6zg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "expo-constants": "~57.0.2",
         "invariant": "^2.2.4"
@@ -7236,6 +7261,7 @@
       "integrity": "sha512-tSlakVnFqdWlXnw5KCFSC1rQU8W5l0Ko8Pb96wi5XU4lCqc0UeLuZCQFpCeAhZGmd91Lo89mCNmr5tnXzZwtFA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "debug": "^4.3.4",
@@ -7251,6 +7277,7 @@
       "integrity": "sha512-Bq0lIOB+olAQrYCS/fZi0cu1i8V0lo/YNr9fqMELerOfYYFkg8zTVrVaRjdFdMYBmz3dtym26UEBxV5dyUYZOg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@expo/env": "~2.4.0"
       },
@@ -7265,6 +7292,7 @@
       "integrity": "sha512-gAGtoEHyGB2ZKN7VT6PFsoV+FWZxg0xKt+3B7ew1DOBO2/ZUR9dEGYXhL6wGGdr+KIMp59AOqogiJBFD+RyFow==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@expo/log-box": "^57.0.0",
         "@expo/metro-runtime": "^57.0.2",
@@ -7340,6 +7368,7 @@
       "integrity": "sha512-sjmbXlGl7807YQ6vYsufkvGItNt/ldXcYnEyF2ERdl0aTs8+xKEarYZ1yefYc3vZvuu7564ToKhtvpEimI8A2w==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@expo/log-box": "^57.0.0",
         "anser": "^1.4.9",
@@ -7365,7 +7394,8 @@
       "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-57.0.0.tgz",
       "integrity": "sha512-mGzjHsozMHQcQiCa5i82rDZuPqKaOwZ5skDc+AkdYiFlWLyUTG7qVmSiIfPye/ByNuWoPkfPnYr8T3aXyDB0EA==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/expo/node_modules/expo-router/node_modules/@expo/ui": {
       "version": "57.0.2",
@@ -7373,6 +7403,7 @@
       "integrity": "sha512-47PaWziMlzhndaccn+Ngzy+3+4/49PvtyvRSjZuNoK/V6zZhOB0EWBWqF6JJnVAo9t5SJmt9e6pXVjiQ7FaGWg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "sf-symbols-typescript": "^2.1.0",
         "vaul": "^1.1.2"
@@ -7403,6 +7434,7 @@
       "integrity": "sha512-v3Ab2l7z6U7tRB4xA0IyKdq0OsqaO1o9ZjsIEoKKnSZ/l96mZz8aCTX0NCXw+YVHJXr8Km4d+Mn6/Q8YjXa+gw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-context": "1.1.4",
@@ -7434,6 +7466,7 @@
       "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.2"
       },
@@ -7458,6 +7491,7 @@
       "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@radix-ui/react-slot": "1.3.0"
       },
@@ -7482,6 +7516,7 @@
       "integrity": "sha512-8Qcnx9447tx/aCBgw6Jenfqg4Skq+vqab9mCBmuGNipIS5YXvL275wbKEu7+ICYHIlAPgCduUMJH1XOYewKF6Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@radix-ui/primitive": "1.1.4",
         "@radix-ui/react-collection": "1.1.11",
@@ -7514,6 +7549,7 @@
       "integrity": "sha512-djW9+zeg137KQdlPtmE8xnaD+K2rcXXMWFrSg0hsmYZ6HRbdTA7tDHFgpaW9+huWVEu0RCabL+985T4TA0BE7g==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.1.4",
@@ -7541,6 +7577,7 @@
       "integrity": "sha512-18byjwFbHVFrGzI4IH1o2MZiiYwvO/y3d+JL3sq50Lg3Id1titwIRMh1fjbHbpM+wP6x14KJY0Ers1UYsjGq8Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.16.0"
       }
@@ -7551,6 +7588,7 @@
       "integrity": "sha512-pLjyiSqOV8NEqs2LqVZmF0cS1j90XoeT2oHbFciVjW7DiV7cP34SGLUgeDsOWY54QkWFR5p2Gz9LZWM8eBsSkA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@expo-google-fonts/material-symbols": "^0.4.1",
         "sf-symbols-typescript": "^2.0.0"
@@ -7568,6 +7606,7 @@
       "integrity": "sha512-Yl82uLkXjXuq7222hWGIDsq5A6R/bsCeCEgdIxQUxAEHf00oRdDnRByLx3Fsij3qwtmYNPGrHV1NH8G8hbCbLQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "color": "^4.2.3",
         "use-latest-callback": "^0.2.4"
@@ -7585,6 +7624,7 @@
       "integrity": "sha512-1Nj1fusFd+rIMKU/qC9yGKVG+3ofh11d3OdBQKL1iVvQfKvcB8vhvTGQf2TkfxW3bamxN+hCZIXmNuU0mRkyDg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
@@ -8443,6 +8483,7 @@
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9764,6 +9805,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10171,6 +10213,7 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -11325,7 +11368,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11345,7 +11387,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -11382,7 +11423,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -11440,7 +11480,6 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -11482,7 +11521,6 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.7.tgz",
       "integrity": "sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "^7.7.2"
@@ -11510,7 +11548,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -11527,7 +11564,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -11543,7 +11579,6 @@
       "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
       "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3",
@@ -11559,7 +11594,6 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -11592,7 +11626,6 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -11703,7 +11736,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11783,6 +11815,7 @@
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -12595,7 +12628,8 @@
       "resolved": "https://registry.npmjs.org/standard-navigation/-/standard-navigation-0.0.5.tgz",
       "integrity": "sha512-YAmzwAiiQVocZxO/VGPFiQHcu5pKiz09QIGC0MK6aRMoa3E0QkoTQgcqJr7ZZ3OMiNhu4DkaGElFI5htjOIDbw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/statuses": {
       "version": "1.5.0",
@@ -12778,6 +12812,7 @@
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "min-indent": "^1.0.0"
       },
@@ -13050,7 +13085,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13257,7 +13291,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",
+    "expo-secure-store": "~15.0.8",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
     "expo-symbols": "~1.0.8",

--- a/utils/auth-token.ts
+++ b/utils/auth-token.ts
@@ -2,6 +2,7 @@ import * as SecureStore from "expo-secure-store";
 
 const JWT_KEY = "jwt";
 const EMAIL_KEY = "email";
+const ROLE_KEY = "role";
 
 export async function saveJwt(token: string): Promise<void> {
   await SecureStore.setItemAsync(JWT_KEY, token);
@@ -25,4 +26,16 @@ export async function getEmail(): Promise<string | null> {
 
 export async function clearEmail(): Promise<void> {
   await SecureStore.deleteItemAsync(EMAIL_KEY);
+}
+
+export async function saveRole(role: string): Promise<void> {
+  await SecureStore.setItemAsync(ROLE_KEY, role);
+}
+
+export async function getRole(): Promise<string | null> {
+  return SecureStore.getItemAsync(ROLE_KEY);
+}
+
+export async function clearRole(): Promise<void> {
+  await SecureStore.deleteItemAsync(ROLE_KEY);
 }

--- a/utils/auth-token.ts
+++ b/utils/auth-token.ts
@@ -1,6 +1,7 @@
 import * as SecureStore from "expo-secure-store";
 
 const JWT_KEY = "jwt";
+const EMAIL_KEY = "email";
 
 export async function saveJwt(token: string): Promise<void> {
   await SecureStore.setItemAsync(JWT_KEY, token);
@@ -12,4 +13,16 @@ export async function getJwt(): Promise<string | null> {
 
 export async function clearJwt(): Promise<void> {
   await SecureStore.deleteItemAsync(JWT_KEY);
+}
+
+export async function saveEmail(email: string): Promise<void> {
+  await SecureStore.setItemAsync(EMAIL_KEY, email);
+}
+
+export async function getEmail(): Promise<string | null> {
+  return SecureStore.getItemAsync(EMAIL_KEY);
+}
+
+export async function clearEmail(): Promise<void> {
+  await SecureStore.deleteItemAsync(EMAIL_KEY);
 }

--- a/utils/auth-token.ts
+++ b/utils/auth-token.ts
@@ -1,0 +1,15 @@
+import * as SecureStore from "expo-secure-store";
+
+const JWT_KEY = "jwt";
+
+export async function saveJwt(token: string): Promise<void> {
+  await SecureStore.setItemAsync(JWT_KEY, token);
+}
+
+export async function getJwt(): Promise<string | null> {
+  return SecureStore.getItemAsync(JWT_KEY);
+}
+
+export async function clearJwt(): Promise<void> {
+  await SecureStore.deleteItemAsync(JWT_KEY);
+}

--- a/utils/user-info.ts
+++ b/utils/user-info.ts
@@ -1,0 +1,13 @@
+import * as SecureStore from "expo-secure-store";
+
+export async function saveInfo(key: string, value: string): Promise<void> {
+  await SecureStore.setItemAsync(key, value);
+}
+
+export async function getInfo(key: string): Promise<string | null> {
+  return SecureStore.getItemAsync(key);
+}
+
+export async function clearInfo(key: string): Promise<void> {
+  await SecureStore.deleteItemAsync(key);
+}


### PR DESCRIPTION
## What I did
This pull request encompasses a lot of changes that were awkward to make in separate pull requests because of waiting for backend and other conflicts. I did the following things:

1. Change to backend deployed apis
2. Add logout functionality
3. Render `name`, `team`, `email`, and whether `checked_in` or not on the home + settings page
4. Render QR code screen according to participant (show your QR code) or admin (scan a QR code)

## Logout
<img width="378" height="826" alt="Screenshot 2026-07-27 at 10 30 47 AM" src="https://github.com/user-attachments/assets/0f878cda-2dbb-4fec-83c0-8b85231ee50a" />

## Render stuff (Home + Settings)
<img width="370" height="809" alt="Screenshot 2026-07-27 at 10 30 07 AM" src="https://github.com/user-attachments/assets/86b693a9-d96e-4fbc-b936-023176cef8dd" />

## Testing
I did `npm install` and `npm start` on iOS simulator.

Note that the showing QR code can be called with success on postman, but I'm having trouble rendering it on frontend (next task for me).

#### Important
If you're doing something that uses the backend like logging in, you **may** have to wait up to 60 seconds if there's backend inactivity. Please be patient!

## Existing stuff
Note that my changes _don't_ break the recent calendar changes, as I rebased mine on top of them!

<img width="385" height="836" alt="Screenshot 2026-07-27 at 10 30 24 AM" src="https://github.com/user-attachments/assets/d74a9078-3784-4fa2-87d9-f78269f8aa83" />