### PR TITLE
Fix special characters checker

### DIFF
--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -153,7 +153,7 @@ export default function Signup() {
       if (/^[0-9]$/.test(letter)) {
         hasNumber = true;
       }
-      if (/^\S$/.test(letter)) {
+      if (/[^a-zA-Z0-9 ]/.test(letter)) {
         hasSpecial = true;
       }
     }


### PR DESCRIPTION
## What I did
I was stress testing the signup page and while it worked for **checking numbers** and **minimum length requirements**, it failed the special character checking.

Now the password checker should be fine.

## Testing
What you can do is replicate `/[^a-zA-Z0-9 ]/.test(letter)` in some file and check if it works for special characters. No need to do unit tests.