### PR TITLE
Fix wrapping characters in settings

### DIFF
--- a/app/(tabs)/(home)/settings.tsx
+++ b/app/(tabs)/(home)/settings.tsx
@@ -98,7 +98,22 @@ export default function SettingsScreen() {
       <View style={styles.content}>
         <View style={styles.profileHeader}>
           <View style={styles.identity}>
-            <Text style={styles.name}>{name}</Text>
+            <View style={styles.nameWrap}>
+              {name
+                .trim()
+                .split(/\s+/)
+                .filter(Boolean)
+                .map((word, i, words) => (
+                  <Text
+                    key={`${word}-${i}`}
+                    numberOfLines={1}
+                    style={styles.name}
+                  >
+                    {word}
+                    {i < words.length - 1 ? " " : ""}
+                  </Text>
+                ))}
+            </View>
             <Text style={styles.profileLabel}>Profile</Text>
           </View>
 
@@ -265,8 +280,14 @@ const styles = StyleSheet.create({
   name: {
     color: "#9BD31B",
     fontFamily: "Grandstander_900Black",
-    fontSize: 40,
+    fontSize: 36,
     lineHeight: 44,
+  },
+  nameWrap: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    maxHeight: 132,
+    overflow: "hidden",
   },
   pill: {
     backgroundColor: "#9BD31B",


### PR DESCRIPTION

## What I did
In this pull request, I fixed the wrapping around issue. First I arbitrarily decreased `fontSize` because I thought it looked nicer. Secondly, I added a flex wrap for characters exceeding horizontal position to wrap to next line.

#### Sample test
Leonardooo de Farias            |  Neymar Junior
:-------------------------:|:-------------------------:
<img width="397" height="823" alt="Screenshot 2026-08-04 at 4 51 18 PM" src="https://github.com/user-attachments/assets/1fc83f4f-015e-4985-97ce-b20e0bc42fe5" />  |  <img width="389" height="828" alt="Screenshot 2026-08-04 at 4 51 56 PM" src="https://github.com/user-attachments/assets/5760f213-79d9-4594-98c6-1329ea6f57a3" />

**Note:** the name I inputted was "Leonardooo" not "Leonardo". It only does **...** for wrapping if it _needs_ to.

## Testing
Just try it with different names and comment any cases this code may fail on.