### PR TITLE
Implement forgot password

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -31,6 +31,7 @@ export default function RootLayout() {
         <Stack.Screen name="index" />
         <Stack.Screen name="login" />
         <Stack.Screen name="signup" />
+        <Stack.Screen name="forgot-password" />
         <Stack.Screen name="(tabs)" />
         <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
       </Stack>

--- a/app/forgot-password.tsx
+++ b/app/forgot-password.tsx
@@ -1,0 +1,412 @@
+import { API_BASE_URL } from "@/constants/computer-ip";
+import {
+  Fredoka_600SemiBold,
+  Fredoka_700Bold,
+  useFonts,
+} from "@expo-google-fonts/fredoka";
+import { router } from "expo-router";
+import { useRef, useState } from "react";
+import {
+  Image,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+export default function ForgotPassword() {
+  const insets = useSafeAreaInsets();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [awaitingCode, setAwaitingCode] = useState(false);
+  const [digits, setDigits] = useState<string[]>(["", "", "", "", ""]);
+  const [submitting, setSubmitting] = useState(false);
+  const digitRefs = useRef<(TextInput | null)[]>([]);
+  const [fontsLoaded] = useFonts({
+    Fredoka_600SemiBold,
+    Fredoka_700Bold,
+  });
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: "#fff",
+    },
+    scrollContent: {
+      flexGrow: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      paddingHorizontal: 16,
+    },
+    input: {
+      width: "80%",
+      height: 45,
+      margin: 6,
+      borderWidth: 0,
+      padding: 10,
+      borderColor: "black",
+      borderRadius: 9,
+      fontSize: 16,
+      color: "gray",
+      backgroundColor: "#eaeaea",
+    },
+    passwordInput: {
+      marginTop: 18,
+    },
+    subtitle1: {
+      fontFamily: "Fredoka_700Bold",
+      fontSize: 20,
+      color: "black",
+    },
+    subtitle2: {
+      fontFamily: "Fredoka_700Bold",
+      fontSize: 20,
+      color: "#A3CE26",
+      marginBottom: 40,
+    },
+    normaltext: {
+      marginTop: 25,
+      fontSize: 10,
+      color: "black",
+    },
+    urltext: {
+      marginLeft: 5,
+      marginTop: 25,
+      fontSize: 10,
+      color: "#99c024",
+    },
+    error: {
+      color: "red",
+      marginLeft: "15%",
+      marginRight: "15%",
+      textAlign: "center",
+    },
+    copyright: {
+      fontSize: 10,
+      color: "#a4a4a4",
+      marginTop: 48,
+      marginBottom: 24,
+      textAlign: "center",
+    },
+    sidebyside: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      marginTop: 8,
+    },
+    logo: {
+      width: "70%",
+      height: 90,
+      marginBottom: 32,
+      resizeMode: "contain",
+    },
+    button: {
+      width: "80%",
+      marginTop: 20,
+      borderRadius: 9,
+      backgroundColor: "#A3CE26",
+      padding: 10,
+    },
+    codeHint: {
+      fontSize: 14,
+      color: "#555",
+      textAlign: "center",
+      marginBottom: 24,
+      marginHorizontal: 24,
+    },
+    codeRow: {
+      flexDirection: "row",
+      justifyContent: "center",
+      gap: 10,
+      marginBottom: 8,
+    },
+    codeDigit: {
+      width: 48,
+      height: 56,
+      borderRadius: 9,
+      backgroundColor: "#eaeaea",
+      fontSize: 24,
+      color: "#111",
+      textAlign: "center",
+      fontFamily: "Fredoka_700Bold",
+    },
+  });
+
+  const invalidPassword = (value: string) => {
+    let hasAlpha = false;
+    let hasNumber = false;
+    let hasSpecial = false;
+    for (const letter of value) {
+      if (/^[a-zA-Z]$/.test(letter)) {
+        hasAlpha = true;
+      }
+      if (/^[0-9]$/.test(letter)) {
+        hasNumber = true;
+      }
+      if (/[^a-zA-Z0-9 ]/.test(letter)) {
+        hasSpecial = true;
+      }
+    }
+    return !(hasAlpha && hasNumber && hasSpecial);
+  };
+
+  const formatCurtime = () => new Date().toISOString().slice(0, 19);
+
+  const handleSendCode = async () => {
+    setErrorMessage(null);
+
+    if (!email) {
+      setErrorMessage("Please enter your email");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/generate-user-code`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email }),
+      });
+
+      if (!response.ok) {
+        setErrorMessage("Failed to send verification code");
+        return;
+      }
+
+      setDigits(["", "", "", "", ""]);
+      setPassword("");
+      setConfirmPassword("");
+      setAwaitingCode(true);
+    } catch {
+      setErrorMessage("Unable to connect to server");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleResetPassword = async () => {
+    if (submitting) {
+      return;
+    }
+
+    setErrorMessage(null);
+
+    const code = digits.join("");
+    if (code.length !== 5) {
+      setErrorMessage("Please enter the 5-digit code");
+      return;
+    }
+
+    if (!password || !confirmPassword) {
+      setErrorMessage("Please fill in all fields");
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setErrorMessage("Passwords do not match");
+      return;
+    }
+
+    if (password.length < 8) {
+      setErrorMessage("Password must be at least 8 characters long");
+      return;
+    }
+
+    if (invalidPassword(password)) {
+      setErrorMessage(
+        "Password must contain a letter, number, and special character",
+      );
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/verify-user-code`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email,
+          inputted_code: code,
+          curtime: formatCurtime(),
+          newPassword: password,
+        }),
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        setErrorMessage(
+          message?.trim() || "Invalid or expired code",
+        );
+        setDigits(["", "", "", "", ""]);
+        digitRefs.current[0]?.focus();
+        return;
+      }
+
+      router.replace("/login");
+    } catch {
+      setErrorMessage("Unable to connect to server");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDigitChange = (index: number, value: string) => {
+    const digit = value.replace(/[^0-9]/g, "").slice(-1);
+    const next = [...digits];
+    next[index] = digit;
+    setDigits(next);
+
+    if (digit && index < 4) {
+      digitRefs.current[index + 1]?.focus();
+    }
+  };
+
+  const handleDigitKeyPress = (index: number, key: string) => {
+    if (key === "Backspace" && !digits[index] && index > 0) {
+      digitRefs.current[index - 1]?.focus();
+    }
+  };
+
+  if (!fontsLoaded) {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      <ScrollView
+        contentContainerStyle={[
+          styles.scrollContent,
+          {
+            paddingTop: insets.top + 24,
+            paddingBottom: insets.bottom + 16,
+          },
+        ]}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Image
+          source={require("../assets/images/icon.png")}
+          style={styles.logo}
+        />
+        <Text style={styles.subtitle1}>Forgot your</Text>
+        <Text style={styles.subtitle2}>password?</Text>
+
+        {awaitingCode ? (
+          <>
+            <Text style={styles.codeHint}>
+              Enter the 5-digit code sent to {email}, then choose a new
+              password
+            </Text>
+            <View style={styles.codeRow}>
+              {digits.map((digit, index) => (
+                <TextInput
+                  key={index}
+                  ref={(ref) => {
+                    digitRefs.current[index] = ref;
+                  }}
+                  style={styles.codeDigit}
+                  value={digit}
+                  onChangeText={(value) => handleDigitChange(index, value)}
+                  onKeyPress={({ nativeEvent }) =>
+                    handleDigitKeyPress(index, nativeEvent.key)
+                  }
+                  keyboardType="number-pad"
+                  maxLength={1}
+                  autoFocus={index === 0}
+                  selectTextOnFocus
+                  editable={!submitting}
+                />
+              ))}
+            </View>
+            <TextInput
+              placeholder="New password"
+              style={[styles.input, styles.passwordInput]}
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry
+              editable={!submitting}
+            />
+            <TextInput
+              placeholder="Confirm new password"
+              style={styles.input}
+              value={confirmPassword}
+              onChangeText={setConfirmPassword}
+              secureTextEntry
+              editable={!submitting}
+            />
+            {errorMessage && <Text style={styles.error}>{errorMessage}</Text>}
+            <TouchableOpacity
+              style={styles.button}
+              onPress={handleResetPassword}
+              disabled={submitting}
+            >
+              <Text
+                style={{
+                  color: "white",
+                  textAlign: "center",
+                  fontSize: 17,
+                }}
+              >
+                Reset password
+              </Text>
+            </TouchableOpacity>
+          </>
+        ) : (
+          <>
+            <TextInput
+              placeholder="Email@email.com"
+              style={styles.input}
+              value={email}
+              onChangeText={setEmail}
+              autoCapitalize="none"
+              keyboardType="email-address"
+              editable={!submitting}
+            />
+            {errorMessage && <Text style={styles.error}>{errorMessage}</Text>}
+            <TouchableOpacity
+              style={styles.button}
+              onPress={handleSendCode}
+              disabled={submitting}
+            >
+              <Text
+                style={{
+                  color: "white",
+                  textAlign: "center",
+                  fontSize: 17,
+                }}
+              >
+                Send code
+              </Text>
+            </TouchableOpacity>
+          </>
+        )}
+
+        <View style={styles.sidebyside}>
+          <Text style={styles.normaltext}>Remember your password?</Text>
+          <Pressable
+            onPress={() => router.push("/login")}
+            style={({ pressed }) => [{ opacity: pressed ? 0.8 : 1 }]}
+          >
+            {({ pressed }) => (
+              <Text style={[styles.urltext, pressed && { color: "purple" }]}>
+                Log in
+              </Text>
+            )}
+          </Pressable>
+        </View>
+        <Text style={styles.copyright}>
+          @ 2026 Emory Hacks. All rights reserved
+        </Text>
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/forgot-password.tsx
+++ b/app/forgot-password.tsx
@@ -243,9 +243,7 @@ export default function ForgotPassword() {
 
       if (!response.ok) {
         const message = await response.text();
-        setErrorMessage(
-          message?.trim() || "Invalid or expired code",
-        );
+        setErrorMessage(message?.trim() || "Invalid or expired code");
         setDigits(["", "", "", "", ""]);
         digitRefs.current[0]?.focus();
         return;
@@ -303,8 +301,7 @@ export default function ForgotPassword() {
         {awaitingCode ? (
           <>
             <Text style={styles.codeHint}>
-              Enter the 5-digit code sent to {email}, then choose a new
-              password
+              Enter the 5-digit code sent to {email}, then choose a new password
             </Text>
             <View style={styles.codeRow}>
               {digits.map((digit, index) => (
@@ -363,7 +360,7 @@ export default function ForgotPassword() {
         ) : (
           <>
             <TextInput
-              placeholder="Email@email.com"
+              placeholder="Email@email.edu"
               style={styles.input}
               value={email}
               onChangeText={setEmail}

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -97,6 +97,15 @@ export default function Login() {
       backgroundColor: "#A3CE26",
       padding: 10,
     },
+    forgotPasswordPressable: {
+      alignSelf: "flex-end",
+      marginRight: "10%",
+      marginTop: 4,
+    },
+    forgotPasswordText: {
+      fontSize: 10,
+      color: "#99c024",
+    },
     orRow: {
       width: "80%",
       flexDirection: "row",
@@ -199,6 +208,21 @@ export default function Login() {
           onChangeText={setPassword}
           secureTextEntry
         />
+        <Pressable
+          onPress={() => router.push("/forgot-password")}
+          style={({ pressed }) => [
+            styles.forgotPasswordPressable,
+            { opacity: pressed ? 0.8 : 1 },
+          ]}
+        >
+          {({ pressed }) => (
+            <Text
+              style={[styles.forgotPasswordText, pressed && { color: "purple" }]}
+            >
+              Forgot password?
+            </Text>
+          )}
+        </Pressable>
         {errorMessage && <Text style={{ color: "red" }}>{errorMessage}</Text>}
         <TouchableOpacity style={styles.button} onPress={handleLogin}>
           <Text

--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -169,6 +169,9 @@ export default function Signup() {
     },
   });
 
+  const isEduEmail = (value: string) =>
+    value.trim().slice(-4).toLowerCase() === ".edu";
+
   const invalidPassword = (password: string) => {
     let hasAlpha = false; // anything that's alphabetic
     let hasNumber = false; // anything that's a number
@@ -272,6 +275,11 @@ export default function Signup() {
       return;
     }
 
+    if (!isEduEmail(email)) {
+      setErrorMessage("Your email should be .edu");
+      return;
+    }
+
     if (password !== confirmPassword) {
       setErrorMessage("Passwords do not match");
       return;
@@ -372,7 +380,7 @@ export default function Signup() {
               autoCapitalize="none"
             />
             <TextInput
-              placeholder="Email@email.com"
+              placeholder="Email@email.edu"
               style={styles.input}
               value={email}
               onChangeText={setEmail}


### PR DESCRIPTION
## What I did
In this pull request, I implemented the forgot password page, which requires an email verification code and a new password.

It reuses many of the same routines as signing up/logging in.

## Testing
You should signup with a new account that is _your_ Emory email. You may further test that signup works, but that's the purpose of this pull request. Once you have an `edu`-associated account, visit the login page and click on **Forgot Password?** as shown below:

<img width="381" height="791" alt="Screenshot 2026-08-11 at 12 05 10 PM" src="https://github.com/user-attachments/assets/305f6bd4-cc8d-475a-b7be-d8758a0f6886" />

#### Next
Type in your email and you'll see a verification code:

<img width="388" height="792" alt="Screenshot 2026-08-11 at 12 07 59 PM" src="https://github.com/user-attachments/assets/fb0e34b6-b742-4f1b-815e-1344a16cf5cd" />

#### Next
You'll receive an email as such. It will legitimately expire in 5 minutes.

<img width="383" height="279" alt="Screenshot 2026-08-11 at 12 10 21 PM" src="https://github.com/user-attachments/assets/09862f55-da9f-485c-b989-9ea67af2e1a0" />

#### Error
If you're too late or you type in the wrong code, you'll get the following:
<img width="390" height="801" alt="Screenshot 2026-08-11 at 12 10 53 PM" src="https://github.com/user-attachments/assets/a72c6849-ec53-4b4e-a0db-9d92be4de71e" />

#### Success
Otherwise, you'll be sent directly to `/login`


## Other additions/changes
Currently the backend rejects a registration if the email's suffix is _not_ `.edu` (rightfully so). However, the frontend should clarify that. Therefore, I added code that renders red text saying "Your email should be .edu" when users fail to input such an email.

#### Fails on gmail.com domain
<img width="345" height="734" alt="Screenshot 2026-08-13 at 8 02 01 AM" src="https://github.com/user-attachments/assets/3c2050f7-cd00-413f-b4bc-45cb04b7fdd8" />