### PR TITLE
Wrap-around time textbox when room name is too long

### DIFF
--- a/components/schedule-related/schedule-item.tsx
+++ b/components/schedule-related/schedule-item.tsx
@@ -229,12 +229,16 @@ const styles = StyleSheet.create({
   },
   expandedMetadataPill: {
     borderRadius: 12,
+    maxWidth: "100%",
     paddingHorizontal: 10,
     paddingVertical: 5,
   },
   expandedMetadataRow: {
+    alignItems: "flex-start",
+    flexDirection: "column",
     gap: 6,
     marginTop: 7,
+    width: "100%",
   },
   expandedMetadataText: {
     fontSize: 12,


### PR DESCRIPTION
## What I did
When an event entry is expanded, the time will wrap around to the next line to avoid being clipped off when the room name is too long.

<img width="1206" height="2622" alt="simulator_screenshot_6A387310-F081-4133-AF97-3B0F8AE5C365" src="https://github.com/user-attachments/assets/5a32ebc5-0ca0-4140-a9c4-fcb30f34729f" />