### PR TITLE
Red notification bar dismissal

### DIFF
--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -36,12 +36,15 @@ import {
 } from "@/services/announcements";
 import type { Announcement } from "@/types/announcement";
 import { getEmail, getJwt, saveRole } from "@/utils/auth-token";
-import { saveInfo } from "@/utils/user-info";
+import { getInfo, saveInfo } from "@/utils/user-info";
 
 export default function HomePage() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const [isNoticeExpanded, setIsNoticeExpanded] = useState(false);
+  const [lastReadCreatedAt, setLastReadCreatedAt] = useState<string | null>(
+    null,
+  );
   const [fontsLoaded] = useFonts({
     AlanSans_400Regular,
     AlanSans_500Medium,
@@ -67,6 +70,9 @@ export default function HomePage() {
 
   const featuredAnnouncement = announcements[0];
   const followingAnnouncements = announcements.slice(1);
+  const showUnreadNotice =
+    !!featuredAnnouncement &&
+    featuredAnnouncement.createdAt !== lastReadCreatedAt;
 
   useFocusEffect(
     //this will mount every time the tab is focused on. change back to useEffect
@@ -134,6 +140,12 @@ export default function HomePage() {
           new Date(right.createdAt).getTime() -
           new Date(left.createdAt).getTime(),
       );
+      const savedCreatedAt = await getInfo("lastReadAnnouncement");
+
+      setLastReadCreatedAt(savedCreatedAt);
+      if (newestFirst[0]?.createdAt !== savedCreatedAt) {
+        setIsNoticeExpanded(false);
+      }
       setAnnouncements(newestFirst);
     } catch (error) {
       setAnnouncementError(
@@ -145,6 +157,14 @@ export default function HomePage() {
       setIsLoadingAnnouncements(false);
     }
   }, []);
+
+  const handleNoticePress = async () => {
+    if (!featuredAnnouncement) return;
+
+    setIsNoticeExpanded(true);
+    setLastReadCreatedAt(featuredAnnouncement.createdAt);
+    await saveInfo("lastReadAnnouncement", featuredAnnouncement.createdAt);
+  };
 
   const openCreate = () => {
     setEditingAnnouncement(null);
@@ -271,24 +291,20 @@ export default function HomePage() {
           <Text style={styles.statusText}>No announcements yet.</Text>
         ) : (
           <>
-            <View
-              style={[
-                styles.featuredNotice,
-                isNoticeExpanded && styles.expandedFeaturedNotice,
-              ]}
-            >
-              <NoticeBar
-                notice={featuredAnnouncement}
-                onPress={() =>
-                  setIsNoticeExpanded((isExpanded) => !isExpanded)
-                }
-              />
-            </View>
+            {showUnreadNotice && (
+              <View style={styles.featuredNotice}>
+                <NoticeBar
+                  notice={featuredAnnouncement}
+                  onPress={handleNoticePress}
+                />
+              </View>
+            )}
 
             {isNoticeExpanded ? (
               <NoticeDetailComponent
                 followingNotices={followingAnnouncements}
                 notice={featuredAnnouncement}
+                onClose={() => setIsNoticeExpanded(false)}
               />
             ) : (
               <View style={styles.noticeListViewport}>
@@ -481,9 +497,6 @@ const styles = StyleSheet.create({
     color: "#7DA515",
     fontFamily: "AlanSans_500Medium",
     fontSize: 16,
-  },
-  expandedFeaturedNotice: {
-    marginBottom: 0,
   },
   fab: {
     alignItems: "center",

--- a/components/home/notice-detail-component.tsx
+++ b/components/home/notice-detail-component.tsx
@@ -1,5 +1,5 @@
 import { LinearGradient } from "expo-linear-gradient";
-import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 
 import { DefaultPfp } from "@/components/home/default-pfp";
 import type { Announcement } from "@/types/announcement";
@@ -7,6 +7,7 @@ import type { Announcement } from "@/types/announcement";
 type NoticeDetailComponentProps = {
   followingNotices: Announcement[];
   notice: Announcement;
+  onClose: () => void;
 };
 
 function formatCreatedAt(createdAt: string) {
@@ -25,6 +26,7 @@ function formatCreatedAt(createdAt: string) {
 export function NoticeDetailComponent({
   followingNotices,
   notice,
+  onClose,
 }: NoticeDetailComponentProps) {
   return (
     <View style={styles.container}>
@@ -33,6 +35,9 @@ export function NoticeDetailComponent({
         showsVerticalScrollIndicator={false}
         style={styles.scroll}
       >
+        <Pressable onPress={onClose} style={styles.backButton}>
+          <Text style={styles.backButtonText}>Back to announcements</Text>
+        </Pressable>
         <View style={[styles.divider, styles.topDivider]} />
 
         <View style={styles.headingRow}>
@@ -104,6 +109,15 @@ export function NoticeDetailComponent({
 }
 
 const styles = StyleSheet.create({
+  backButton: {
+    alignSelf: "flex-start",
+    paddingVertical: 8,
+  },
+  backButtonText: {
+    color: "#7DA515",
+    fontFamily: "AlanSans_500Medium",
+    fontSize: 12,
+  },
   author: {
     color: "#A9A9A9",
     fontFamily: "AlanSans_400Regular",


### PR DESCRIPTION
## What I did
- Red bar will go away after clicking
- Logic: comparing the `featuredAnnouncement.createdAt` for featured annoucement (newly posted) with `lastReadCreatedAt`.

## Screenshots:
Unread state:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-16 at 23 23 37" src="https://github.com/user-attachments/assets/94dc72b8-cdc6-446d-9c01-0d840e926b7a" />
Expanded state (note the red bar is gone):
<img width="1206" height="2622" alt="simulator_screenshot_2A577E32-55D0-4232-9B00-0AC80B4DF521" src="https://github.com/user-attachments/assets/06f829aa-e49a-493a-b930-acccbbd5a184" />
After clicking "Back to Announcements":
<img width="1206" height="2622" alt="simulator_screenshot_A8285E49-CE85-4936-8DA0-357FFC342D5D" src="https://github.com/user-attachments/assets/45439728-0849-4854-a4f7-73059303780a" />

## Testing
- Create an announcement
- Click on the red bar

It should dismiss that announcement.