### PR TITLE
Fixed the font size for various displays

### DIFF
--- a/app/forgot-password.tsx
+++ b/app/forgot-password.tsx
@@ -72,13 +72,13 @@ export default function ForgotPassword() {
     },
     normaltext: {
       marginTop: 25,
-      fontSize: 10,
+      fontSize: 14,
       color: "black",
     },
     urltext: {
       marginLeft: 5,
       marginTop: 25,
-      fontSize: 10,
+      fontSize: 14,
       color: "#99c024",
     },
     error: {

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -63,14 +63,14 @@ export default function Login() {
     },
     normaltext: {
       marginTop: 25,
-      fontSize: 10,
+      fontSize: 14,
       color: "black",
     },
     urltext: {
       marginLeft: 5,
       marginTop: 25,
       marginBottom: 100,
-      fontSize: 10,
+      fontSize: 14,
       color: "#99c024",
     },
     copyright: {
@@ -102,7 +102,7 @@ export default function Login() {
       marginTop: 4,
     },
     forgotPasswordText: {
-      fontSize: 10,
+      fontSize: 14,
       color: "#99c024",
     },
   });

--- a/app/signup.tsx
+++ b/app/signup.tsx
@@ -73,13 +73,13 @@ export default function Signup() {
     },
     normaltext: {
       marginTop: 25,
-      fontSize: 10,
+      fontSize: 14,
       color: "black",
     },
     urltext: {
       marginLeft: 5,
       marginTop: 25,
-      fontSize: 10,
+      fontSize: 14,
       color: "#99c024",
     },
     error: {


### PR DESCRIPTION
## What I did
I have fixed the font sizes for the following in various locations:
- Sign Up
- Login
- Forgot Password

#### `Forgot Password` and `Sign Up` in `Login Page`
<img width="1206" height="2622" alt="simulator_screenshot_D20AD442-FBB9-4E61-A06B-E735B75D2329" src="https://github.com/user-attachments/assets/0a5afdf3-a121-4ac5-971d-f5698a745e3a" />

#### `Login` in `Sign Up Page`
<img width="1206" height="2622" alt="simulator_screenshot_D0970035-A433-4CAF-891D-69D0C838432D" src="https://github.com/user-attachments/assets/0e27a6c4-f2fd-4e78-97c1-d7c8c154558e" />

#### `Login` in `Forgot Password`
![simulator_screenshot_58857F4E-33B0-4043-A8BE-F5396001CDE3](https://github.com/user-attachments/assets/16403b0d-0a3f-4f26-9c7d-2064d60993ed)