### PR TITLE
Save user session + keep users logged in

### DIFF
--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -30,12 +30,10 @@ import { NoticeBar } from "@/components/home/notice-bar";
 import { NoticeDetailComponent } from "@/components/home/notice-detail-component";
 import { ProfileComponent } from "@/components/home/profile-component";
 import { API_BASE_URL } from "@/constants/computer-ip";
-import {
-  getAnnouncements,
-  updateAnnouncement,
-} from "@/services/announcements";
+import { getAnnouncements, updateAnnouncement } from "@/services/announcements";
 import type { Announcement } from "@/types/announcement";
-import { getEmail, getJwt, saveRole } from "@/utils/auth-token";
+import { getEmail, getJwt } from "@/utils/auth-token";
+import { saveUserSession } from "@/utils/session";
 import { getInfo, saveInfo } from "@/utils/user-info";
 
 export default function HomePage() {
@@ -105,15 +103,7 @@ export default function HomePage() {
         const userData = await response.json();
         if (!active) return;
 
-        await saveRole(userData.role);
-        await saveInfo("name", userData.name ?? "");
-        await saveInfo("id", String(userData.id ?? ""));
-        await saveInfo("teamName", userData.teamName ?? "");
-        await saveInfo(
-          "points",
-          String(userData.points ?? userData.totalPoints ?? 0),
-        );
-        await saveInfo("checkedIn", String(!!userData.checkedIn));
+        await saveUserSession(userData, email);
         console.log(String(!!userData.checkedIn));
         setName(userData.name);
         setTeamName(userData.teamName);
@@ -125,7 +115,6 @@ export default function HomePage() {
       };
     }, []),
   );
-
 
   const loadAnnouncements = useCallback(async () => {
     setIsLoadingAnnouncements(true);
@@ -237,7 +226,9 @@ export default function HomePage() {
         });
 
         if (!response.ok) {
-          throw new Error((await response.text()) || "Could not post announcement.");
+          throw new Error(
+            (await response.text()) || "Could not post announcement.",
+          );
         }
       }
 
@@ -246,9 +237,7 @@ export default function HomePage() {
       closeCompose();
       Alert.alert(
         wasEditing ? "Updated" : "Posted",
-        wasEditing
-          ? "Announcement updated."
-          : "Announcement published.",
+        wasEditing ? "Announcement updated." : "Announcement published.",
       );
     } catch (error) {
       Alert.alert(
@@ -265,7 +254,6 @@ export default function HomePage() {
       loadAnnouncements();
     }, [loadAnnouncements]),
   );
-
 
   if (!fontsLoaded) {
     return <View style={styles.screen} />;
@@ -477,7 +465,6 @@ const styles = StyleSheet.create({
     color: "#111111",
     fontFamily: "AlanSans_500Medium",
     fontSize: 15,
-    
   },
   errorText: {
     color: "#C93D2A",
@@ -485,7 +472,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
     marginHorizontal: 32,
     textAlign: "center",
-    
   },
   editButton: {
     alignItems: "center",

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,34 @@
-import { Redirect } from "expo-router";
+import { restoreSession } from "@/utils/session";
+import { Redirect, type Href } from "expo-router";
+import { useEffect, useState } from "react";
 
 export default function Index() {
-  return <Redirect href="/login" />; // Change here to test to home page without login.
+  const [href, setHref] = useState<Href | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    (async () => {
+      try {
+        const signedIn = await restoreSession();
+        if (active) {
+          setHref(signedIn ? "/(tabs)/(home)" : "/login");
+        }
+      } catch {
+        if (active) {
+          setHref("/login");
+        }
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (!href) {
+    return null;
+  }
+
+  return <Redirect href={href} />;
 }

--- a/utils/session.ts
+++ b/utils/session.ts
@@ -1,0 +1,89 @@
+import { fetch } from "expo/fetch";
+
+import { API_BASE_URL } from "@/constants/computer-ip";
+
+import { getEmail, getJwt, getRole, saveEmail, saveRole } from "./auth-token";
+import { saveInfo } from "./user-info";
+
+type UserSessionData = {
+  checkedIn?: boolean;
+  email?: string;
+  id?: number | string;
+  name?: string;
+  points?: number;
+  role?: string;
+  teamName?: string;
+  totalPoints?: number;
+};
+
+export async function saveUserSession(
+  userData: UserSessionData,
+  fallbackEmail: string,
+): Promise<void> {
+  await saveEmail(userData.email || fallbackEmail);
+  const actualRole = String(userData.role ?? "participant");
+  if ((await getRole()) !== actualRole) {
+    await saveRole(actualRole);
+  }
+  await saveInfo("name", userData.name ?? "");
+  await saveInfo("id", String(userData.id ?? ""));
+  await saveInfo("teamName", userData.teamName ?? "");
+  await saveInfo(
+    "points",
+    String(userData.points ?? userData.totalPoints ?? 0),
+  );
+  await saveInfo("checkedIn", String(!!userData.checkedIn));
+}
+
+export async function restoreSession(): Promise<boolean> {
+  const jwt = await getJwt();
+  const email = (await getEmail()) || emailFromJwt(jwt);
+
+  if (!jwt || !email) {
+    return false;
+  }
+
+  const response = await fetch(`${API_BASE_URL}/api/users/${email}`, {
+    method: "GET",
+    credentials: "omit",
+    headers: {
+      "Content-Type": "application/json",
+      Cookie: `token=${jwt}`,
+    },
+  });
+
+  if (!response.ok) {
+    return false;
+  }
+
+  const userData = (await response.json()) as UserSessionData;
+  await saveUserSession(userData, email);
+  return true;
+}
+
+function emailFromJwt(token: string | null): string | null {
+  if (!token) return null;
+
+  try {
+    const segment = token.split(".")[1];
+    if (!segment) return null;
+
+    const padded = segment.replace(/-/g, "+").replace(/_/g, "/");
+    const pad =
+      padded.length % 4 === 0 ? "" : "=".repeat(4 - (padded.length % 4));
+    const payload = JSON.parse(atob(padded + pad)) as {
+      email?: unknown;
+      sub?: unknown;
+    };
+
+    if (typeof payload.email === "string" && payload.email) {
+      return payload.email;
+    }
+    if (typeof payload.sub === "string" && payload.sub.includes("@")) {
+      return payload.sub;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What I did
Basically, once users login their information is stored in `expo-secure-store` (already had been implemented). Additionally, users can stay logged for a maximum of 4 days (notably the duration of the jwt). In `index.tsx`, the `useEffect` is mounted once by default, wherein the jwt is used to get user api information. Iff the jwt exists will it automatically route to **home page**. 

## Testing
Those reviewing this pull request should try the following things, perhaps with variations:

1. Login for the first time with your user
2. Exit the app _without logging out_
3. Go back to the screen: this _**should**_ automatically route you to home

Also try the following:
1. Login with your user (you may already be logged in, which is fine)
2. Click on the settings icon
3. Click logout (user session data like jwt should be cleared)
4. Exit the app _without logging out_
5. Go back to the screen: this _**should NOT**_ automatically route you to home. You should have to log in.


I tested on the iOS simulator with legitimate success, but want actual physical device testing on android and iOS.