### PR TITLE
Update brightness upon enter/leave

### DIFF
--- a/app/(tabs)/qrcode.tsx
+++ b/app/(tabs)/qrcode.tsx
@@ -4,6 +4,7 @@ import type { ScheduleEvent } from "@/types/schedule-event";
 import { getJwt, getRole } from "@/utils/auth-token";
 import { Fredoka_700Bold, useFonts } from "@expo-google-fonts/fredoka";
 import Ionicons from "@expo/vector-icons/Ionicons";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useFocusEffect, useIsFocused } from "@react-navigation/native";
 import { Buffer } from "buffer";
 import * as Brightness from "expo-brightness";
@@ -48,8 +49,9 @@ function eventKey(event: ScheduleEvent) {
   return event.title.trim();
 }
 
+const ORIGINAL_BRIGHTNESS_KEY = "originalBrightness";
+
 export default function QRCodeScreen() {
-  const originalBrightness = useRef<number | null>(null);
   const scanLock = useRef(false);
   const insets = useSafeAreaInsets();
   const isFocused = useIsFocused();
@@ -88,6 +90,33 @@ export default function QRCodeScreen() {
 
   useFocusEffect(
     useCallback(() => {
+      (async () => {
+        try {
+          const current = await Brightness.getBrightnessAsync();
+          await AsyncStorage.setItem(ORIGINAL_BRIGHTNESS_KEY, String(current));
+          await Brightness.setBrightnessAsync(1);
+        } catch {
+          // brightness control not available
+        }
+      })();
+
+      return () => {
+        (async () => {
+          try {
+            const saved = await AsyncStorage.getItem(ORIGINAL_BRIGHTNESS_KEY);
+            if (saved != null) {
+              await Brightness.setBrightnessAsync(Number(saved));
+            }
+          } catch {
+            // brightness control not available
+          }
+        })();
+      };
+    }, []),
+  );
+
+  useFocusEffect(
+    useCallback(() => {
       if (isAdmin !== false) {
         if (isAdmin) {
           setScanned(false);
@@ -116,18 +145,6 @@ export default function QRCodeScreen() {
 
       let active = true;
       (async () => {
-        if (active) {
-          try {
-            // Save the original brightness & set to MAX
-            originalBrightness.current = await Brightness.getBrightnessAsync();
-            await Brightness.setBrightnessAsync(1);
-          } catch {
-            // brightness control not available
-          }
-        }
-      })();
-
-      (async () => {
         try {
           const jwt = await getJwt();
           if (!jwt) return;
@@ -151,7 +168,9 @@ export default function QRCodeScreen() {
             response.headers.get("content-type") ?? "image/png";
           const arrayBuffer = await response.arrayBuffer();
           const base64 = Buffer.from(arrayBuffer).toString("base64");
-          setQrCode(`data:${contentType};base64,${base64}`);
+          if (active) {
+            setQrCode(`data:${contentType};base64,${base64}`);
+          }
         } catch (error) {
           console.log("Failed to load QR code", error);
         }
@@ -159,13 +178,6 @@ export default function QRCodeScreen() {
 
       return () => {
         active = false;
-        if (originalBrightness.current !== null) {
-          try {
-            Brightness.setBrightnessAsync(originalBrightness.current);
-          } catch {
-            // brightness control not available
-          }
-        }
       };
     }, [isAdmin]),
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@expo-google-fonts/fredoka": "^0.4.1",
         "@expo-google-fonts/grandstander": "^0.4.1",
         "@expo/vector-icons": "^15.0.3",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-masked-view/masked-view": "0.3.2",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
@@ -2837,6 +2838,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native-masked-view/masked-view": {
@@ -8842,6 +8855,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -9846,6 +9868,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@expo-google-fonts/fredoka": "^0.4.1",
     "@expo-google-fonts/grandstander": "^0.4.1",
     "@expo/vector-icons": "^15.0.3",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-masked-view/masked-view": "0.3.2",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",


### PR DESCRIPTION
## What I did
When clicking on the QR code, the brightness should increase. However, it should decrease or go back to what it originally was upon clicking on another tab. It stores on async storage when clicking on qr tab, then retrieves it to reset brightness when clicking out (not focused).

## Testing
`npm install` (since new package. Plus, just trying out on expo go physical phone.